### PR TITLE
Fall back to a local build when the prebuilt image is unavailable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,32 @@ COMPOSE ?= $(shell \
 	else \
 		echo "docker compose"; \
 	fi)
+CONTAINER ?= $(shell \
+	if command -v docker >/dev/null 2>&1; then \
+		echo "docker"; \
+	elif command -v podman >/dev/null 2>&1; then \
+		echo "podman"; \
+	else \
+		echo "docker"; \
+	fi)
+IMAGE ?= ghcr.io/duoan/torchcode:latest
 
 .PHONY: run run-build stop clean setup-local badges
 
 run:
 	@echo "Using compose backend: $(COMPOSE)"
 	@echo "Pulling prebuilt image (if available)..."
-	@$(COMPOSE) pull || true
-	$(COMPOSE) up -d --no-build
+	@pull_status=0; \
+	$(COMPOSE) pull || pull_status=$$?; \
+	if $(CONTAINER) image inspect $(IMAGE) >/dev/null 2>&1; then \
+		if [ $$pull_status -ne 0 ]; then \
+			echo "Prebuilt image pull failed, but a local copy is available. Reusing $(IMAGE)."; \
+		fi; \
+		$(COMPOSE) up -d --no-build; \
+	else \
+		echo "Prebuilt image unavailable for this platform. Building locally instead..."; \
+		$(COMPOSE) up --build -d; \
+	fi
 	@echo ""
 	@echo "🔥 TorchCode is running!"
 	@echo "   Open http://localhost:8888"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ CONTAINER ?= $(shell \
 	else \
 		echo "docker"; \
 	fi)
-IMAGE ?= ghcr.io/duoan/torchcode:latest
 
 .PHONY: run run-build stop clean setup-local badges
 
@@ -22,10 +21,17 @@ run:
 	@echo "Using compose backend: $(COMPOSE)"
 	@echo "Pulling prebuilt image (if available)..."
 	@pull_status=0; \
+	images="$$( $(COMPOSE) config --images 2>/dev/null )"; \
 	$(COMPOSE) pull || pull_status=$$?; \
-	if $(CONTAINER) image inspect $(IMAGE) >/dev/null 2>&1; then \
+	missing_images=""; \
+	for image in $$images; do \
+		if ! $(CONTAINER) image inspect "$$image" >/dev/null 2>&1; then \
+			missing_images="$$missing_images $$image"; \
+		fi; \
+	done; \
+	if [ -n "$$images" ] && [ -z "$$missing_images" ]; then \
 		if [ $$pull_status -ne 0 ]; then \
-			echo "Prebuilt image pull failed, but a local copy is available. Reusing $(IMAGE)."; \
+			echo "Prebuilt image pull failed, but local compose images are available. Reusing them."; \
 		fi; \
 		$(COMPOSE) up -d --no-build; \
 	else \

--- a/README.md
+++ b/README.md
@@ -88,11 +88,15 @@ hint("relu")       # show a hint
 docker run -p 8888:8888 -e PORT=8888 ghcr.io/duoan/torchcode:latest
 ```
 
+If the registry image is unavailable for your platform, use Option 2 instead. This is the common path on Apple Silicon / `arm64`.
+
 ### Option 2 — Build locally
 
 ```bash
 make run
 ```
+
+`make run` will try the prebuilt image first and automatically fall back to a local build when needed.
 
 Open **<http://localhost:8888>** — that's it. Works with both Docker and Podman (auto-detected).
 


### PR DESCRIPTION
This fixes the startup path on Apple Silicon and other `arm64` environments where `ghcr.io/duoan/torchcode:latest` is not published.

Right now `make run` always tries `docker compose up -d --no-build` after the pull step, so a missing registry image turns into a hard failure even though the repo can be built locally.

What changed:
- keep using the prebuilt image when it exists locally or pulls successfully
- fall back to `docker compose up --build -d` when the image is unavailable for the current platform
- add a short README note so Apple Silicon users know what to expect

Validation:
- ran `make run` on `arm64` and confirmed it switched from the failed pull to a local build
- confirmed the container came up successfully with `docker compose ps`