### PR TITLE
fix(api): Multi-Head Attention problem fails to load in web UI

### DIFF
--- a/api/parser.py
+++ b/api/parser.py
@@ -45,6 +45,11 @@ def parse_notebook_template(filepath: str) -> dict:
             "initial_code": "# Error loading template code."
         }
 
+# Template filenames whose stem doesn't match their torch_judge task module name
+TASK_ID_ALIASES = {
+    "multihead_attention": "mha",
+}
+
 def get_all_templates(templates_dir: str = "../templates") -> dict:
     """
     Returns a dictionary mapping task_ids to their extracted template data.
@@ -65,6 +70,7 @@ def get_all_templates(templates_dir: str = "../templates") -> dict:
         match = re.match(r"^\d+_(.+)\.ipynb$", filename)
         if match:
             task_id = match.group(1)
+            task_id = TASK_ID_ALIASES.get(task_id, task_id)
             templates[task_id] = parse_notebook_template(filepath)
             
     return templates


### PR DESCRIPTION
## Problem

In the standalone Web UI (Option 3), the **Multi-Head Attention** problem shows the fallback content — `Description not found.` and `# Write your code here.` — instead of the real problem statement and starter code.

## Root cause

`api/parser.py` infers template keys from notebook filenames (`06_multihead_attention.ipynb` → `multihead_attention`), while the task registry derives task ids from module names (`torch_judge/tasks/mha.py` → `mha`). The two never match for this problem, so `GET /api/tasks/mha` finds no template. It is the only one of the 40 problems with this mismatch.

## Fix

Add a small alias table in the parser mapping the filename-derived key to the registry task id. Renaming the notebook instead would break the GitHub/Colab links in the README, so the alias approach keeps everything intact.

## Verification

- `GET /api/tasks/mha` now returns the full description (incl. LaTeX) and the `MultiHeadAttention` starter template.
- Scanned all 40 tasks via the API: none serve fallback content anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCQsdwqyWkT3aPdex9b9jt